### PR TITLE
Add renovate config

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,0 +1,19 @@
+{
+  "extends": [
+    // https://docs.renovatebot.com/presets-config/#configjs-lib
+    "config:js-lib",
+
+    // https://docs.renovatebot.com/presets-default/#maintainlockfilesweekly
+    ":maintainLockFilesWeekly",
+
+    // https://docs.renovatebot.com/presets-default/#preservesemverranges
+    ":preserveSemverRanges",
+
+    // https://docs.renovatebot.com/presets-npm/#npmunpublishsafe
+    "npm:unpublishSafe",
+
+    // https://docs.renovatebot.com/presets-schedule/#scheduledaily
+    "schedule:earlyMondays",
+  ],
+  "rebaseWhen": "never",
+}


### PR DESCRIPTION
This just copies over the config we have for Renovate within the [Carbon monorepo](https://github.com/carbon-design-system/carbon/blob/81364cdcee30ef84db0181f5f761b7f62f3bfc77/.github/renovate.json5#L1-L19)

Most notably it specifies that semver ranges should be kept for dependencies rather than having dependencies pinned.