### PR TITLE
remove import of BookmarkFilledMotion

### DIFF
--- a/src/components/Operations/index.js
+++ b/src/components/Operations/index.js
@@ -1,5 +1,4 @@
 import BookmarkMotion from './BookmarkMotion';
-import BookmarkFilledMotion from './BookmarkFilledMotion';
 import ExploreMotion from './ExploreMotion';
 
 export { BookmarkMotion, ExploreMotion };


### PR DESCRIPTION
`BookmarkFilledMotion` was being imported to `/operations/index.js` but the component itself has not been pushed yet.  I removed it from the file until it is ready.  