### PR TITLE
Grid responsiveness and styling

### DIFF
--- a/example/src/app.scss
+++ b/example/src/app.scss
@@ -2,7 +2,7 @@
 	width: 100%;
 	display: flex;
 	justify-content: center;
-	align-items: center;
+	text-align: center;
 	padding: 160px 0 32px 0;
 	opacity: 0;
 	transform: scale(0.8);
@@ -11,9 +11,10 @@
 }
 
 .icon-tile {
-	margin: 8px;
+	margin: 0px;
 	padding: 12px;
 	background-color: #f4f4f4;
+	border: 1px solid #e0e0e0;
 	display: flex;
 	flex-direction: column;
 	align-items: flex-start;
@@ -70,5 +71,28 @@ h2 {
 @keyframes fade-in {
 	100% {
 		opacity: 1;
+	}
+}
+
+@media (min-width: 42rem) {
+	.icon-tiles-grid {
+		display: grid;
+		padding-left: 12px;
+		grid-template-columns: repeat(4,1fr);
+	}
+
+	.icon-tile svg{
+		margin: 38px 50px;
+	}
+}
+
+@media (min-width: 66rem) {
+	.icon-tiles-grid {
+		display: grid;
+		grid-template-columns: repeat(6,1fr);
+	}
+
+	.icon-tile svg{
+		margin: 48px 60px;
 	}
 }

--- a/example/src/components/NavigationSection/NavigationSection.js
+++ b/example/src/components/NavigationSection/NavigationSection.js
@@ -57,7 +57,7 @@ const NavigationSection = () => {
         <div className='bx--row'>
           <h2>Navigation</h2>
         </div>
-  			<ul className='bx--row'>
+  			<ul className='bx--row icon-tiles-grid'>
   				<li
             className='icon-tile'
             onMouseEnter={() => setAddAnimating(true)}

--- a/example/src/components/OperationsSection/OperationsSection.js
+++ b/example/src/components/OperationsSection/OperationsSection.js
@@ -92,7 +92,7 @@ const OperationsSection = () => {
         <div className='bx--row'>
           <h2>Operations</h2>
         </div>
-  			<ul className='bx--row'>
+  			<ul className='bx--row icon-tiles-grid'>
           <li
             className='icon-tile'
             onMouseEnter={() => setAddCommentAnimating(true)}


### PR DESCRIPTION
I added media queries to make the grid of the icons responsive by using the same method they did in carbon, also styled the tiles to look similar to carbons
<img width="1376" alt="Screenshot 2022-12-30 at 10 35 17 AM" src="https://user-images.githubusercontent.com/48833213/210092511-96e43189-1b12-437b-a9ab-1092aa609ec2.png">
