### PR TITLE
chore(project): add DCO workflow

### DIFF
--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -1,0 +1,31 @@
+name: "DCO Assistant"
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened, closed, synchronize]
+
+jobs:
+  DCO:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "DCO Assistant"
+        if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the DCO document and I hereby sign the DCO.') || github.event_name == 'pull_request_target'
+        uses: cla-assistant/github-action@v2.3.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PERSONAL_ACCESS_TOKEN: ${{ secrets.DCO.PERSONAL_ACCESS_TOKEN }}
+        with:
+          path-to-signatures: "dco-signatures.json"
+          path-to-document: "https://github.com/carbon-design-system/carbon-dco/blob/main/dco.md"
+          branch: "main"
+          allowlist: bot*
+          remote-organization-name: carbon-design-system
+          remote-repository-name: carbon-dco
+          create-file-commit-message: "chore: create file to store dco signatures"
+          signed-commit-message: "chore: $contributorName has signed the dco in #$pullRequestNo"
+          custom-notsigned-prcomment: "Thanks for your submission! We ask that $you sign our [Developer Certificate of Origin](https://github.com/carbon-design-system/carbon-dco/blob/main/dco.md) before we can accept your contribution. You can sign the DCO by adding a comment below using this text:"
+          custom-pr-sign-comment: "I have read the DCO document and I hereby sign the DCO."
+          custom-allsigned-prcomment: "All contributors have signed the DCO."
+          lock-pullrequest-aftermerge: false
+          use-dco-flag: true


### PR DESCRIPTION
Hey there! This PR adds the DCO Assistant which ensures that all collaborators submitting PRs have signed the Developer Certificate of Origin. 

All projects in the org need to have the DCO configured. I've already generated the token and added it to repository secrets. It shares the same central list as all other repos to determine if users have signed the DCO or not.