### PR TITLE
feat: remove container div example

### DIFF
--- a/src/components/Formatting/CopyMotion/CopyMotion.js
+++ b/src/components/Formatting/CopyMotion/CopyMotion.js
@@ -10,7 +10,6 @@ const CopyMotion = (props) => {
   }, [props.isAnimating])
 
   const shouldAnimate = isAnimating ? styles.isAnimating : ''
-  console.log('shouldAnimate', shouldAnimate)
 
   return (
     <svg

--- a/src/components/Formatting/CopyMotion/CopyMotion.js
+++ b/src/components/Formatting/CopyMotion/CopyMotion.js
@@ -5,29 +5,29 @@ const CopyMotion = (props) => {
   const iconRef = useRef(null)
   const [isAnimating, setIsAnimating] = useState(props.isAnimating)
 
-  let iconStyles = {
-    width: props.size,
-    height: props.size
-  }
-
   useEffect(() => {
     setIsAnimating(props.isAnimating)
   }, [props.isAnimating])
 
   const shouldAnimate = isAnimating ? styles.isAnimating : ''
+  console.log('shouldAnimate', shouldAnimate)
 
   return (
-    <div ref={iconRef} className={`${shouldAnimate}`}>
-      <svg style={iconStyles} viewBox='0 0 32 32' className={styles.CopyMotion}>
-        <title>Copy</title>
-        <path className={styles.CopyTop} d='M4,18H2V4A2,2,0,0,1,4,2H18V4H4Z' />
-        <path
-          className={styles.CopyBottom}
-          d='M28,10V28H10V10H28m0-2H10a2,2,0,0,0-2,2V28a2,2,0,0,0,2,2H28a2,2,0,0,0,2-2V10a2,2,0,0,0-2-2Z'
-        />
-        <rect id='_Transparent_Rectangle_' fill='none' width='32' height='32' />
-      </svg>
-    </div>
+    <svg
+      ref={iconRef}
+      viewBox='0 0 32 32'
+      className={`${shouldAnimate}`}
+      aria-label='Copy'
+      width={props.size}
+      height={props.size}
+    >
+      <path className={styles.CopyTop} d='M4,18H2V4A2,2,0,0,1,4,2H18V4H4Z' />
+      <path
+        className={styles.CopyBottom}
+        d='M28,10V28H10V10H28m0-2H10a2,2,0,0,0-2,2V28a2,2,0,0,0,2,2H28a2,2,0,0,0,2-2V10a2,2,0,0,0-2-2Z'
+      />
+      <rect id='_Transparent_Rectangle_' fill='none' width='32' height='32' />
+    </svg>
   )
 }
 


### PR DESCRIPTION

This is a proof of concept for removing the container div around the svgs. Doing this would pull this library in line with the static Carbon Icons package and make them interchangeable within Carbon components. You can view some of the issues/discrepencies between motion icons and Carbon icons in this [example](https://stackblitz.com/edit/github-jxsika-hbx1zu?file=src%2FApp.jsx,src%2Findex.scss) here.

#### Changelog

- Remove container div
- Remove title
- Add aria-label instead of tittle
- Add width and height instead of inline style

